### PR TITLE
Support building with Cabal 1.18

### DIFF
--- a/codex.cabal
+++ b/codex.cabal
@@ -31,7 +31,7 @@ library
   build-depends:       
       base                >= 4.6.0.1    && < 5
     , bytestring          >= 0.10.0.2   && < 0.11
-    , Cabal               >= 1.19       && < 1.21
+    , Cabal               >= 1.18       && < 1.21
     , containers          >= 0.5.0.0    && < 0.6
     , directory           >= 1.2.0.1    && < 1.3
     , download-curl       >= 0.1.4      && < 0.2


### PR DESCRIPTION
Is there a reason the lower bound for Cabal is 1.19? I was able to build codex with 1.18.
Since 1.18 is the version of the Cabal library bundled with GHC 7.8, I think it should be supported.
