### PR TITLE
Hackage database is no longer under ~/Library/Haskell/repo-cache on OSX.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 dist
+cabal.sandbox.config
+*.swp
+tags
+codex.tags

--- a/src/Distribution/Hackage/Utils.hs
+++ b/src/Distribution/Hackage/Utils.hs
@@ -8,11 +8,5 @@ import System.FilePath
 getHackagePath :: IO FilePath
 getHackagePath = do
  homedir <- getHomeDirectory
- return (joinPath [homedir,
-#ifdef IS_DARWIN
-    "Library", "Haskell", "repo-cache"
-#else
-    ".cabal", "packages"
-#endif
-    , "hackage.haskell.org"])
+ return (joinPath [homedir, ".cabal", "packages", "hackage.haskell.org"])
 


### PR DESCRIPTION
Related issue: peti/hackage-db#2
