### PR TITLE
Much better emacs support out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 This tool download and cache the source code of packages in your local hackage,
 it can then use this local cache to generate a `tags` file aggregating the sources of all the dependencies of a given cabal project.
 
-You basically do `codex update` in your cabal project directory and you'll get a `codex.tags` file
-that you can use in your favorite text editor.
+You basically do `codex update` in your cabal project directory and you'll get a file (`codex.tags` by default, or `TAGS` when using
+emacs format) that you can use in your favorite text editor.
 
-*By default the generated `codex.tags` will include tags of the current project as well, this functionality can be disabled in your `~/codex` file.*
+*By default the generated tags file will include tags of the current
+ project as well, this functionality can be disabled in your `~/codex`
+ file.*
 
 ## Install
 
@@ -24,7 +26,7 @@ By default `hasktags` will be used, and need to be in the `PATH`, the tagger com
 
     codex [update] [cache clean] [set tagger [hasktags|ctags]] [set format [vim|emacs|sublime]]
 
-* **update**: Synchronize the `codex.tags` file in the current cabal project directory (use --force to discard tags file hash)
+* **update**: Synchronize the tags file in the current cabal project directory (use --force to discard tags file hash)
 * **cache clean**: Remove all `tags` file from the local hackage cache
 * **set tagger [hasktags|ctags]**: Update the `~/.codex` configuration file for the given tagger
 * **set format [vim|emacs|sublime]**: Update the `~/.codex` configuration file for the given format

--- a/codex.cabal
+++ b/codex.cabal
@@ -4,9 +4,10 @@ synopsis:            A ctags file generator for cabal project dependencies.
 description:         
   This tool download and cache the source code of packages in your local hackage,
   it can then use this cache to generate `tags` files aggregating the sources of all the dependencies of your cabal projects.
-  . 
-  You basically do `codex update` in your cabal project directory and you'll get a `codex.tags` file
-  that you can use in your favorite text editor.
+  .
+  You basically do `codex update` in your cabal project directory and you'll get a file
+  (`codex.tags` by default, or `TAGS` when using emacs format) that you can use in your
+  favorite text editor.
   .
   Usage overview can be found in the <http://github.com/aloiscochard/codex#codex README>.
 
@@ -55,6 +56,7 @@ executable codex
     Main.Config
     Main.Config.Codex0
     Main.Config.Codex1
+    Main.Config.Codex2
   build-depends:       
       base
     , Cabal

--- a/codex/Main.hs
+++ b/codex/Main.hs
@@ -29,9 +29,6 @@ retrying n x = retrying' n $ fmap (left (:[])) x where
     Left ls -> fmap (left (++ ls)) x
     Right r -> return $ Right r
 
-tagsFile :: FilePath
-tagsFile = joinPath ["codex.tags"]
-
 hashFile :: Codex -> FilePath
 hashFile cx = hackagePath cx </> "codex.hash"
 
@@ -65,7 +62,7 @@ update cx force = do
 
   shouldUpdate <-
     if (null workspaceProjects') then
-      either (const True) id <$> (runEitherT $ isUpdateRequired cx tagsFile dependencies projectHash)
+      either (const True) id <$> (runEitherT $ isUpdateRequired cx dependencies projectHash)
     else return True
 
   if (shouldUpdate || force) then do
@@ -81,6 +78,7 @@ update cx force = do
   else
     putStrLn "Nothing to update."
   where
+    tagsFile = tagsFileName cx
     getTags i = status cx i >>= \x -> case x of
       (Source Tagged)   -> return ()
       (Source Untagged) -> tags cx i >>= (const $ getTags i)
@@ -93,8 +91,8 @@ help = putStrLn $
           , "             [--help]"
           , "             [--version]"
           , ""
-          , " update                Synchronize the `codex.tags` file in the current cabal project directory"
-          , " update --force        Discard `codex.tags` file hash and force regeneration"
+          , " update                Synchronize the tags file in the current cabal project directory"
+          , " update --force        Discard tags file hash and force regeneration"
           , " cache clean           Remove all `tags` file from the local hackage cache]"
           , " set tagger <tagger>   Update the `~/.codex` configuration file for the given tagger (hasktags|ctags)."
           , " set format <format>   Update the `~/.codex` configuration file for the given format (vim|emacs|sublime)."
@@ -113,7 +111,7 @@ main = do
     run cx ["update", "--force"]  = withConfig cx (\x -> update x True)
     run cx ["set", "tagger", "ctags"]     = encodeConfig $ cx { tagsCmd = taggerCmd Ctags }
     run cx ["set", "tagger", "hasktags"]  = encodeConfig $ cx { tagsCmd = taggerCmd Hasktags }
-    run cx ["set", "format", "emacs"]     = encodeConfig $ cx { tagsCmd = taggerCmd HasktagsEmacs, tagsFileHeader = False, tagsFileSorted = False }
+    run cx ["set", "format", "emacs"]     = encodeConfig $ cx { tagsCmd = taggerCmd HasktagsEmacs, tagsFileHeader = False, tagsFileSorted = False, tagsFileName = "TAGS" }
     run cx ["set", "format", "sublime"]   = encodeConfig $ cx { tagsCmd = taggerCmd HasktagsExtended, tagsFileHeader = True, tagsFileSorted = True }
     run cx ["set", "format", "vim"]       = encodeConfig $ cx { tagsFileHeader = True, tagsFileSorted = True }
     run cx ["--version"] = putStrLn $ concat ["codex: ", display version]

--- a/codex/Main/Config/Codex0.hs
+++ b/codex/Main/Config/Codex0.hs
@@ -16,4 +16,4 @@ migrateWarn :: IO ()
 migrateWarn = return ()
 
 migrate :: Codex -> New.Codex
-migrate cx = New.Codex True (hackagePath cx) (tagsCmd cx) True True
+migrate cx = New.Codex True (hackagePath cx) (tagsCmd cx) True True New.defaultTagsFileName

--- a/codex/Main/Config/Codex1.hs
+++ b/codex/Main/Config/Codex1.hs
@@ -14,8 +14,8 @@ instance FromJSON Codex
 
 migrateWarn :: IO ()
 migrateWarn = do
-  putStrLn "\tThe `codex.tags` will now include the tags of the *current* project as well,"
+  putStrLn "\tThe tags file will now include the tags of the *current* project as well,"
   putStrLn "\tif that is not the behavior you want, please edit `~/.codex`."
 
 migrate :: Codex -> New.Codex
-migrate cx = New.Codex True (hackagePath cx) (tagsCmd cx) (tagsFileHeader cx) (tagsFileSorted cx)
+migrate cx = New.Codex True (hackagePath cx) (tagsCmd cx) (tagsFileHeader cx) (tagsFileSorted cx) New.defaultTagsFileName

--- a/codex/Main/Config/Codex2.hs
+++ b/codex/Main/Config/Codex2.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Main.Config.Codex2 where
+
+import Data.Yaml
+import GHC.Generics
+
+import qualified Codex as New
+
+data Codex = Codex { currentProjectIncluded :: Bool, hackagePath :: FilePath, tagsCmd :: String, tagsFileHeader :: Bool, tagsFileSorted :: Bool }
+  deriving Generic
+
+instance ToJSON Codex
+instance FromJSON Codex
+
+migrateWarn :: IO ()
+migrateWarn = return ()
+
+migrate :: Codex -> New.Codex
+migrate cx =
+  New.Codex True (hackagePath cx) (tagsCmd cx) (tagsFileHeader cx) (tagsFileSorted cx) New.defaultTagsFileName

--- a/src/Codex.hs
+++ b/src/Codex.hs
@@ -1,4 +1,4 @@
-module Codex (Codex(..), Verbosity, module Codex) where
+module Codex (Codex(..), defaultTagsFileName, Verbosity, module Codex) where
 
 import Control.Exception (try, SomeException)
 import Control.Monad
@@ -83,8 +83,8 @@ computeCurrentProjectHash cx = if not $ currentProjectIncluded cx then return "*
       p fp = any (\f -> f fp) (fmap List.isSuffixOf extensions)
       extensions = [".hs", ".lhs", ".hsc"]
 
-isUpdateRequired :: Codex -> FilePath -> [PackageIdentifier] -> String -> Action Bool
-isUpdateRequired cx file ds ph = do
+isUpdateRequired :: Codex -> [PackageIdentifier] -> String -> Action Bool
+isUpdateRequired cx ds ph = do
   fileExist <- tryIO $ doesFileExist file
   if fileExist then do
     content <- tryIO $ TLIO.readFile file
@@ -92,6 +92,8 @@ isUpdateRequired cx file ds ph = do
     return $ hash /= (Text.pack $ tagsFileHash cx ds ph)
   else
     return True
+  where
+    file = tagsFileName cx
 
 status :: Codex -> PackageIdentifier -> Action Status
 status cx i = do

--- a/src/Codex/Internal.hs
+++ b/src/Codex/Internal.hs
@@ -6,12 +6,16 @@ import Distribution.Text
 import Distribution.Verbosity
 import System.FilePath
 
+defaultTagsFileName :: FilePath
+defaultTagsFileName = "codex.tags"
+
 data Codex = Codex
   { currentProjectIncluded :: Bool
   , hackagePath :: FilePath
   , tagsCmd :: String
   , tagsFileHeader :: Bool
-  , tagsFileSorted :: Bool }
+  , tagsFileSorted :: Bool
+  , tagsFileName :: FilePath }
     deriving Show
 
 packagePath :: Codex -> PackageIdentifier -> FilePath


### PR DESCRIPTION
Have emacs format set the command to --etags and not --ctags (only --etags works with emacs).

Make the tags file name configurable, and have it be "TAGS" by default, which is much more emacs-friendly.

A couple of cleanups (redundant imports, overly strict version bounds).
