### PR TITLE
When looking for cabal file, disregard misleading directories

### DIFF
--- a/src/Codex/Project.hs
+++ b/src/Codex/Project.hs
@@ -47,7 +47,9 @@ allDependencies pd = List.filter (not . isCurrent) $ concat [lds, eds, tds, bds]
 
 findPackageDescription :: FilePath -> IO (Maybe GenericPackageDescription)
 findPackageDescription root = do
-  files <- getDirectoryContents root
+  contents <- getDirectoryContents root
+  isFile <- sequence $ map doesFileExist contents
+  let files = map fst $ filter snd $ zip contents isFile
   traverse (readPackageDescription silent) $ fmap (\x -> root </> x) $ List.find (List.isSuffixOf ".cabal") files
 
 resolveCurrentProjectDependencies :: IO ProjectDependencies


### PR DESCRIPTION
This corrects an edge case I discovered when working in a project which contains a directory called `.cabal`. That filename "suffix" tricks `findPackageDescription` into attempting to `readPackageDescription` on a directory which breaks codex.

This pull request disregards directories in `findPackageDescription`