### PR TITLE
codex.cabal: use local codex library, not already installed one

### DIFF
--- a/codex.cabal
+++ b/codex.cabal
@@ -77,8 +77,8 @@ executable codex
     , process
     , transformers
     , wreq
-    , yaml                
-    , codex               == 0.5.0.0
+    , yaml
+    , codex
 
 source-repository head
   type:     git


### PR DESCRIPTION
I've noticed it when updated to codex-0.5.0.1 from hackage.
It's executable contained dependency on codex-0.5.0.0 library.

Use local just-built library.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>