### PR TITLE
Project packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ before_install:
   - unset CC
   # Download and unpack the stack executable
   - mkdir -p ~/.local/bin
-  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v1.1.2/stack-1.1.2-linux-x86_64.tar.gz | tar -xvzf -
-  - mv stack-1.1.2-linux-x86_64/stack ~/.local/bin
+  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v1.6.3/stack-1.6.3-linux-x86_64.tar.gz | tar -xvzf -
+  - mv stack-1.6.3-linux-x86_64/stack ~/.local/bin
   - export PATH=~/.local/bin:$PATH
   - stack --version
 
 script:
   - export STACK_YAML=stack-$GHCVER.yaml
-  - stack --no-terminal --install-ghc build
-  - cd test && ./test.sh
+  - stack --no-terminal --install-ghc build --copy-bins
+  - test/test.sh

--- a/codex.cabal
+++ b/codex.cabal
@@ -33,7 +33,7 @@ library
       ascii-progress      >= 0.3
     , base                >= 4.6.0.1    && < 5
     , bytestring          >= 0.10.0.2   && < 0.11
-    , Cabal               >= 1.18       && < 1.25
+    , Cabal               >= 1.18       && < 2.1
     , cryptohash          >= 0.11       && < 0.12
     , containers          >= 0.5.0.0    && < 0.6
     , directory           >= 1.2.0.1    && < 1.4
@@ -44,7 +44,7 @@ library
     , lens                >= 4.6        && < 5
     , machines            >= 0.2        && < 0.7
     , machines-directory  >= 0.0.0.2    && < 0.3
-    , process             >= 1.2.3      && < 1.5
+    , process             >= 1.2.3      && < 1.7
     , tar                 >= 0.4.0.1    && < 0.6
     , text                >= 1.1.1.3    && < 1.3
     , transformers        >= 0.3.0.0    && < 0.6

--- a/codex/Main.hs
+++ b/codex/Main.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP #-}
 
+module Main (main) where
+
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>))
 import Data.Traversable (traverse)
@@ -12,6 +14,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Either hiding (left, right)
 import Data.Either
 import Data.List
+import Data.Maybe (isJust)
 import Data.String.Utils
 import Distribution.Text
 import Network.Socket (withSocketsDo)
@@ -73,7 +76,7 @@ writeCacheHash cx = writeFile $ hashFile cx
 
 update :: Bool -> Codex -> Builder -> IO ()
 update force cx bldr = displayConsoleRegions $ do
-  (project, dependencies, workspaceProjects') <- resolveCurrentProjectDependencies bldr $ hackagePath cx </> "00-index.tar"
+  (mpid, dependencies, workspaceProjects') <- resolveCurrentProjectDependencies bldr $ hackagePath cx </> "00-index.tar"
   projectHash <- computeCurrentProjectHash cx
 
   shouldUpdate <-
@@ -82,17 +85,25 @@ update force cx bldr = displayConsoleRegions $ do
     else return True
 
   if force || shouldUpdate then do
-    let workspaceProjects = if not $ currentProjectIncluded cx then workspaceProjects'
-        else (WorkspaceProject project ".") : workspaceProjects'
+    incCurrProj <- includeCurrentPackage cx
+    let workspaceProjects = case mpid of
+          Nothing -> workspaceProjects'
+          Just p -> if incCurrProj
+            then [WorkspaceProject p "."] `union` workspaceProjects'
+            else workspaceProjects'
     fileExist <- doesFileExist tagsFile
     when fileExist $ removeFile tagsFile
-    putStrLn $ concat ["Updating ", display project]
+    putStrLn ("Updating: " ++ displayPackages mpid workspaceProjects)
     results <- withSession $ \s -> do
       tick' <- newProgressBar' "Loading tags" (length dependencies)
       traverse (retrying 3 . runEitherT . getTags tick' s) dependencies
     _       <- traverse print . concat $ lefts results
     res     <- runEitherT $ assembly bldr cx dependencies projectHash workspaceProjects tagsFile
-    either print (const $ return ()) res
+    case res of
+      Left e -> do
+        print e
+        exitFailure
+      Right _ -> pure ()
   else
     putStrLn "Nothing to update."
   where
@@ -108,6 +119,19 @@ update force cx bldr = displayConsoleRegions $ do
             putStrLn $ concat ["codex: *warning* unable to fetch an archive for ", display i]
             putStrLn msg
             return ()
+    displayPackages mpid workspaceProjects =
+      case mpid of
+        Just p -> display p
+        Nothing ->
+          unwords (fmap (display . workspaceProjectIdentifier) workspaceProjects)
+
+-- | Determine whether the package in the working directory, if present, should
+-- be included.
+includeCurrentPackage :: Codex -> IO Bool
+includeCurrentPackage cx =
+  if currentProjectIncluded cx
+  then isJust <$> findCabalFilePath "."
+  else pure False
 
 help :: IO ()
 help = putStrLn $

--- a/src/Codex/Internal.hs
+++ b/src/Codex/Internal.hs
@@ -80,9 +80,9 @@ readStackPath opts id' = do
   s <- readCreateProcess (shell cmd) ""
   return $ init s
 
-stackListDependencies :: String -> IO [PackageIdentifier]
-stackListDependencies opts = do
-    let cmd = concat ["stack ", opts,  " list-dependencies"]
+stackListDependencies :: String -> String -> IO [PackageIdentifier]
+stackListDependencies opts pname = do
+    let cmd = concat ["stack ", opts, " list-dependencies ", pname]
     s <- readCreateProcess (shell cmd) ""
     return $ mapMaybe parsePackageIdentifier $ lines s
   where

--- a/src/Codex/Project.hs
+++ b/src/Codex/Project.hs
@@ -7,8 +7,9 @@ import Data.Traversable (traverse)
 #endif
 
 import Control.Exception (try, SomeException)
-import Control.Monad
+import Data.Bool (bool)
 import Data.Function
+import Data.List (delete, union)
 import Data.Maybe
 import Distribution.InstalledPackageInfo
 import Distribution.Hackage.DB (Hackage, readHackage')
@@ -22,6 +23,7 @@ import Distribution.Simple.PackageIndex
 import Distribution.Verbosity
 import Distribution.Version
 import System.Directory
+import System.Environment (lookupEnv)
 import System.FilePath
 import Text.Read (readMaybe)
 
@@ -37,7 +39,7 @@ newtype Workspace = Workspace [WorkspaceProject]
 data WorkspaceProject = WorkspaceProject { workspaceProjectIdentifier :: PackageIdentifier, workspaceProjectPath :: FilePath }
   deriving (Eq, Show)
 
-type ProjectDependencies = (PackageIdentifier, [PackageIdentifier], [WorkspaceProject])
+type ProjectDependencies = (Maybe PackageIdentifier, [PackageIdentifier], [WorkspaceProject])
 
 identifier :: GenericPackageDescription -> PackageIdentifier
 identifier = package . packageDescription
@@ -52,14 +54,56 @@ allDependencies pd = List.filter (not . isCurrent) $ concat [lds, eds, tds, bds]
 
 findPackageDescription :: FilePath -> IO (Maybe GenericPackageDescription)
 findPackageDescription root = do
-  contents  <- getDirectoryContents root
-  files     <- filterM (doesFileExist . (</>) root) contents
-  traverse (readPackageDescription silent) $ fmap (\x -> root </> x) $ List.find (List.isSuffixOf ".cabal") files
+  mpath <- findCabalFilePath root
+  traverse (readPackageDescription silent) mpath
+
+-- | Find a regular file ending with ".cabal" within a directory.
+findCabalFilePath :: FilePath -> IO (Maybe FilePath)
+findCabalFilePath path = do
+  paths <- getDirectoryContents path
+  case List.find ((&&) <$> dotCabal <*> visible) paths of
+    Just p -> do
+      let p' = path </> p
+      bool Nothing (Just p') <$> doesFileExist p'
+    Nothing -> pure Nothing
+  where
+    dotCabal = (".cabal" ==) . takeExtension
+    visible  = not . List.isPrefixOf "."
 
 resolveCurrentProjectDependencies :: Builder -> FilePath -> IO ProjectDependencies
 resolveCurrentProjectDependencies bldr hackagePath = do
-  ws <- getWorkspace ".."
-  resolveProjectDependencies bldr ws hackagePath "."
+  mps <- localPackages
+  case mps of
+    Just ps -> resolveLocalDependencies bldr hackagePath ps
+    Nothing -> do
+      disableImplicitWorkspace <- isJust <$> lookupEnv "CODEX_DISABLE_WORKSPACE"
+      ws <- if disableImplicitWorkspace
+        then pure (Workspace [])
+        else getWorkspace ".."
+      resolveProjectDependencies bldr ws hackagePath "."
+  where
+    localPackages = do
+      mpath <-
+        case bldr of
+          Cabal -> bool Nothing (Just ".") <$> doesFileExist "cabal.project"
+          Stack _ -> pure (Just ".")
+      case mpath of
+        Nothing -> pure Nothing
+        Just path -> do
+          Workspace ps <- getWorkspace path
+          Just . maybe ps (: ps) <$> readWorkspaceProject "."
+
+-- | Resolve the dependencies of each local project package.
+resolveLocalDependencies :: Builder -> FilePath -> [WorkspaceProject] -> IO ProjectDependencies
+resolveLocalDependencies bldr hackagePath wps = do
+  pids <- foldr mergeDependencies mempty <$> traverse resolve wps
+  pure (Nothing, pids, wps)
+  where
+    resolve p@WorkspaceProject{workspaceProjectPath = packagePath} =
+      let ws' = Workspace (delete p wps)
+      in resolveProjectDependencies bldr ws' hackagePath packagePath
+    mergeDependencies (_, pids, _) pids' =
+      pids `union` pids'
 
 -- TODO Optimize
 resolveProjectDependencies :: Builder -> Workspace -> FilePath -> FilePath -> IO ProjectDependencies
@@ -70,7 +114,8 @@ resolveProjectDependencies bldr ws hackagePath root = do
   let zs   = resolveWorkspaceDependencies ws pd
   let wsds = List.filter (shouldOverride xs) $ List.nubBy (on (==) prjId) $ concat [ys, zs]
   let pjds = List.filter (\x -> List.notElem (pkgName x) $ fmap prjId wsds) xs
-  return (identifier pd, pjds, wsds) where
+  return (Just (identifier pd), pjds, wsds)
+  where
     shouldOverride xs (WorkspaceProject x _) =
       maybe True (\y -> pkgVersion x >= pkgVersion y) $ List.find (\y -> pkgName x == pkgName y) xs
     prjId = pkgName . workspaceProjectIdentifier
@@ -87,8 +132,11 @@ resolveInstalledDependencies bldr root pd = try $ do
           xs = fmap sourcePackageId $ ys
       return xs where
         withCabal = getPersistBuildConfig $ root </> "dist"
-    Stack cmd -> let self = package (packageDescription pd)
-             in  filter (/=self) <$> stackListDependencies cmd
+    Stack cmd ->
+      filter (/= pid) <$> stackListDependencies cmd pname
+  where
+    pid = pd & packageDescription & package
+    pname = pid & pkgName & unPackageName
 
 allComponentsInBuildOrder' :: LocalBuildInfo -> [ComponentLocalBuildInfo]
 allComponentsInBuildOrder' =

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,27 +1,28 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
-pwd
+cd "$(dirname "$0")/.."
 
-
-cd .. && stack install && stack install hasktags
-
-export STACK_YAML="stack.yaml"
+stack install hasktags
 
 rm -f ~/.codex
 rm -f ./test/test-project/codex.tags
 rm -f ./test/test-project/TAGS
 
-cd ./test/test-project && codex set tagger hasktags && codex set format emacs && stack exec -- codex update
+cd ./test/test-project
+codex set tagger hasktags
+codex set format emacs
+codex update
 
-cd ..
-
-tagsFile=test-project/codex.tags
-tagsHash=$(sha1sum "$tagsFile" | awk '{print $1}')
-
-echo "$tagsHash"
+tagsFile=codex.tags
 
 # This is a dumb canary until better tests can be written
 ## This is disabled because the SHA1 isn't deterministic on TravisCI. No idea why.
+# cd ..
+# tagsHash=$(sha1sum "$tagsFile" | awk '{print $1}')
+
+# echo "$tagsHash"
+
 # if [ "$tagsHash" != "71594f46fc81822371c48516048e301f98467781" ]
 # then
 #     echo "TAGS SHA1 hash didn't match expected value, was: "

--- a/test/test.sh
+++ b/test/test.sh
@@ -9,6 +9,7 @@ rm -f ~/.codex
 rm -f ./test/test-project/codex.tags
 rm -f ./test/test-project/TAGS
 
+export STACK_YAML="stack.yaml"
 cd ./test/test-project
 codex set tagger hasktags
 codex set format emacs


### PR DESCRIPTION
Note: This includes changes from pull/75 in order for CI to work.

 Look for project packages in sub-directories (#55)

+ Disable implicit workspace (../) with env var CODEX_DISABLE_WORKSPACE

If Codex detects a stack.yaml or cabal.project file in the current directory, it
will search for local packages in sub-directories. If those files are not
present, it will behave as it did previously (treating ../ as a "workspace").