### PR TITLE
Drop dependency on either and support hackage-db 2.0

### DIFF
--- a/codex.cabal
+++ b/codex.cabal
@@ -38,7 +38,7 @@ library
     , containers          >= 0.5.0.0    && < 0.6
     , directory           >= 1.2.0.1    && < 1.4
     , filepath            >= 1.3.0.1    && < 1.5
-    , hackage-db          >= 1.22       && < 2
+    , hackage-db          >= 1.22       && < 2.1
     , http-client         >= 0.4        && < 0.6
     , lens                >= 4.6        && < 5
     , machines            >= 0.2        && < 0.7

--- a/codex.cabal
+++ b/codex.cabal
@@ -37,7 +37,6 @@ library
     , cryptohash          >= 0.11       && < 0.12
     , containers          >= 0.5.0.0    && < 0.6
     , directory           >= 1.2.0.1    && < 1.4
-    , either              >= 4.3.0.1    && < 4.5
     , filepath            >= 1.3.0.1    && < 1.5
     , hackage-db          >= 1.22       && < 2
     , http-client         >= 0.4        && < 0.6
@@ -70,7 +69,6 @@ executable codex
     , Cabal
     , bytestring
     , directory
-    , either
     , filepath
     , hackage-db
     , MissingH            >= 1.2.1.0    && < 1.5

--- a/codex/Main/Config.hs
+++ b/codex/Main/Config.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Main.Config where
 
 import Data.Yaml
@@ -31,7 +32,11 @@ checkConfig cx = do
 loadConfig :: IO Codex
 loadConfig = decodeConfig >>= maybe defaultConfig return where
   defaultConfig = do
+#if MIN_VERSION_hackage_db(2,0,0)
+    hp <- DB.hackageTarball
+#else
     hp <- DB.hackagePath
+#endif
     let cx = Codex True (dropFileName hp) defaultStackOpts (taggerCmd Hasktags) True True defaultTagsFileName
     encodeConfig cx
     return cx

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -1,0 +1,7 @@
+resolver: lts-11.2
+packages:
+- '.'
+flags: {}
+extra-package-dbs: []
+nix:
+  packages: [zlib]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-8.0.yaml
+stack-8.2.yaml


### PR DESCRIPTION
This drops the dependency on the `either` package since that no longer provides the `EitherT` transformer. Instead the code now uses `ExceptT`.

In addition to that it adds support for `hackage-db-2.0` (without dropping support for older versions).

I’ve also added a `stack.yaml` to test this.