### PR TITLE
Provide an informative error message if Hackage path not found

### DIFF
--- a/codex/Main/Config.hs
+++ b/codex/Main/Config.hs
@@ -36,16 +36,16 @@ loadConfig = decodeConfig >>= maybe defaultConfig return where
   defaultConfig = do
 #if MIN_VERSION_hackage_db(2,0,0)
     hp <- DB.hackageTarball
-#else
-    hp <- DB.hackagePath
-#endif
-      `catch` \Errors.NoHackageTarballFound ->
+      `catch` \Errors.NoHackageTarballFound -> do
         error $ unlines
           [ "couldn't find a Hackage tarball. This can happen if you use `stack` exclusively,"
           , "or just haven't run `cabal update` yet. To fix it, try running:"
           , ""
           , "    cabal update"
           ]
+#else
+    hp <- DB.hackagePath
+#endif
     let cx = Codex True (dropFileName hp) defaultStackOpts (taggerCmd Hasktags) True True defaultTagsFileName
     encodeConfig cx
     return cx

--- a/codex/Main/Config.hs
+++ b/codex/Main/Config.hs
@@ -13,7 +13,10 @@ import qualified Main.Config.Codex1 as C1
 import qualified Main.Config.Codex2 as C2
 import qualified Main.Config.Codex3 as C3
 import qualified Distribution.Hackage.DB as DB
+
+#if MIN_VERSION_hackage_db(2,0,0)
 import qualified Distribution.Hackage.DB.Errors as Errors
+#endif
 
 data ConfigState = Ready | TaggerNotFound
 

--- a/codex/Main/Config.hs
+++ b/codex/Main/Config.hs
@@ -41,8 +41,9 @@ loadConfig = decodeConfig >>= maybe defaultConfig return where
 #endif
       `catch` \Errors.NoHackageTarballFound ->
         error $ unlines
-          [ "codex couldn't find a Hackage tarball. This can happen if you haven't run `cabal` directly yet."
-          , "Try running:"
+          [ "couldn't find a Hackage tarball. This can happen if you use `stack` exclusively,"
+          , "or just haven't run `cabal update` yet. To fix it, try running:"
+          , ""
           , "    cabal update"
           ]
     let cx = Codex True (dropFileName hp) defaultStackOpts (taggerCmd Hasktags) True True defaultTagsFileName


### PR DESCRIPTION
Before:

```
$ mv ~/.cabal ~/.cabal.backup
$ mv ~/.codex ~/.codex.backup
$ codex
codex: NoHackageTarballFound
```

After:

```
$ codex
codex: couldn't find a Hackage tarball. This can happen if you use `stack` exclusively,
or just haven't run `cabal update` yet. To fix it, try running:

    cabal update

CallStack (from HasCallStack):
  error, called at codex/Main/Config.hs:43:9 in main:Main.Config
```