### PR TITLE
Now compiles with ghc 8.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
   - $HOME/.stack
 
 env:
- - GHCVER=7.10
+# - GHCVER=7.10
  - GHCVER=8.0
  - GHCVER=8.2.2
  - GHCVER=8.4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,33 @@
 language: c
 sudo: false
 
-addons:
-  apt:
-    packages:
-      - libgmp-dev
 
 # Caching so the next build will be fast too.
 cache:
   directories:
   - $HOME/.ghc
-  - $HOME/.cabal
   - $HOME/.stack
 
 env:
  - GHCVER=7.10
  - GHCVER=8.0
+ - GHCVER=8.2.2
+ - GHCVER=8.4.2
 
 before_install:
   - unset CC
   # Download and unpack the stack executable
   - mkdir -p ~/.local/bin
-  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v1.6.3/stack-1.6.3-linux-x86_64.tar.gz | tar -xvzf -
-  - mv stack-1.6.3-linux-x86_64/stack ~/.local/bin
+  - travis_retry curl -L  https://github.com/commercialhaskell/stack/releases/download/v1.6.3/stack-1.6.3-linux-x86_64.tar.gz  | tar -xvzf -
+  - cp stack-1.6.3-linux-x86_64/stack ~/.ghc/
+  - cp ~/.ghc/stack ~/.local/bin
   - export PATH=~/.local/bin:$PATH
+  - mkdir -p ~/.cabal/packages
+  - ln -s ~/.stack/indices/Hackage  ~/.cabal/packages/hackage.haskell.org
+  - cp -f stack-$GHCVER.yaml stack.yaml
+  - cp -f stack-$GHCVER.yaml test/test-project/stack.yaml
   - stack --version
 
 script:
-  - export STACK_YAML=stack-$GHCVER.yaml
   - stack --no-terminal --install-ghc build --copy-bins
   - test/test.sh

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,9 @@ build-7.10:
 
 build-8.0:
 	STACK_YAML="stack-8.0.yaml" stack build
+
+build-8.2:
+	STACK_YAML="stack-8.2.yaml" stack build
+
+build-8.4.2:
+	STACK_YAML="stack-8.4.yaml" stack build

--- a/codex.cabal
+++ b/codex.cabal
@@ -1,85 +1,84 @@
-name:                codex
-version:             0.5.1.2
-synopsis:            A ctags file generator for cabal project dependencies.
+cabal-version: >=1.10
+name: codex
+version: 0.5.1.3
+license: Apache-2.0
+license-file: LICENSE
+maintainer: alois.cochard@gmail.com
+author: Alois Cochard
+homepage: http://github.com/aloiscochard/codex
+synopsis: A ctags file generator for cabal project dependencies.
 description:
-  This tool download and cache the source code of packages in your local hackage,
-  it can then use this cache to generate `tags` files aggregating the sources of all the dependencies of your cabal/stack projects.
-  .
-  You basically do `codex update` in your project directory and you'll get a file
-  (`codex.tags` by default, or `TAGS` when using emacs format) that you can use in your
-  favorite text editor.
-  .
-  Usage overview can be found in the <http://github.com/aloiscochard/codex#codex README>.
-
-homepage:            http://github.com/aloiscochard/codex
-license:             Apache-2.0
-license-file:        LICENSE
-author:              Alois Cochard
-maintainer:          alois.cochard@gmail.com
-category:            Development
-build-type:          Simple
-cabal-version:       >=1.10
-
-library
-  default-language:  Haskell2010
-  hs-source-dirs:    src
-  ghc-options:       -Wall
-  exposed-modules:
-    Codex
-    Codex.Project
-    Codex.Internal
-    Distribution.Sandbox.Utils
-  build-depends:
-      ascii-progress      >= 0.3
-    , base                >= 4.6.0.1    && < 5
-    , bytestring          >= 0.10.0.2   && < 0.11
-    , Cabal               >= 1.18       && < 2.1
-    , cryptohash          >= 0.11       && < 0.12
-    , containers          >= 0.5.0.0    && < 0.6
-    , directory           >= 1.2.0.1    && < 1.4
-    , filepath            >= 1.3.0.1    && < 1.5
-    , hackage-db          >= 1.22       && < 2.1
-    , http-client         >= 0.4        && < 0.6
-    , lens                >= 4.6        && < 5
-    , machines            >= 0.2        && < 0.7
-    , machines-directory  >= 0.0.0.2    && < 0.3
-    , process             >= 1.2.3      && < 1.7
-    , tar                 >= 0.4.0.1    && < 0.6
-    , text                >= 1.1.1.3    && < 1.3
-    , transformers        >= 0.3.0.0    && < 0.6
-    , yaml                >= 0.8.8.3    && < 0.9
-    , wreq                >= 0.3.0.1    && < 0.6
-    , zlib                >= 0.5.4.1    && < 0.7
-
-executable codex
-  default-language:  Haskell2010
-  hs-source-dirs:    codex
-  main-is:           Main.hs
-  ghc-options:       -threaded -Wall
-  other-modules:
-    Main.Config
-    Main.Config.Codex0
-    Main.Config.Codex1
-    Main.Config.Codex2
-    Main.Config.Codex3
-    Paths_codex
-  build-depends:
-      ascii-progress
-    , base
-    , Cabal
-    , bytestring
-    , directory
-    , filepath
-    , hackage-db
-    , MissingH            >= 1.2.1.0    && < 1.5
-    , monad-loops         >= 0.4.2      && < 0.5
-    , network             >= 2.6        && < 2.7
-    , process
-    , transformers
-    , wreq
-    , yaml
-    , codex
+    This tool download and cache the source code of packages in your local hackage,
+    it can then use this cache to generate `tags` files aggregating the sources of all the dependencies of your cabal/stack projects.
+    .
+    You basically do `codex update` in your project directory and you'll get a file
+    (`codex.tags` by default, or `TAGS` when using emacs format) that you can use in your
+    favorite text editor.
+    .
+    Usage overview can be found in the <http://github.com/aloiscochard/codex#codex README>.
+category: Development
+build-type: Simple
 
 source-repository head
-  type:     git
-  location: https://github.com/aloiscochard/codex.git
+    type: git
+    location: https://github.com/aloiscochard/codex.git
+
+library
+    exposed-modules:
+        Codex
+        Codex.Project
+        Codex.Internal
+        Distribution.Sandbox.Utils
+    hs-source-dirs: src
+    default-language: Haskell2010
+    ghc-options: -Wall
+    build-depends:
+        ascii-progress ==0.3.*,
+        base >=4.6.0.1 && <5,
+        bytestring >=0.10.0.2 && <0.11,
+        Cabal >=1.18 && <2.3,
+        cryptohash ==0.11.*,
+        containers >=0.5.0.0 && <0.6,
+        directory >=1.2.0.1 && <1.4,
+        filepath >=1.3.0.1 && <1.5,
+        hackage-db >=1.22 && <2.1,
+        http-client >=0.4 && <0.6,
+        lens >=4.6 && <5,
+        machines >=0.2 && <0.7,
+        machines-directory >=0.0.0.2 && <0.3,
+        process >=1.2.3 && <1.7,
+        tar >=0.4.0.1 && <0.6,
+        text >=1.1.1.3 && <1.3,
+        transformers >=0.3.0.0 && <0.6,
+        yaml >=0.8.8.3 && <0.9,
+        wreq >=0.3.0.1 && <0.6,
+        zlib >=0.5.4.1 && <0.7
+
+executable codex
+    main-is: Main.hs
+    hs-source-dirs: codex
+    other-modules:
+        Main.Config
+        Main.Config.Codex0
+        Main.Config.Codex1
+        Main.Config.Codex2
+        Main.Config.Codex3
+        Paths_codex
+    default-language: Haskell2010
+    ghc-options: -threaded -Wall
+    build-depends:
+        ascii-progress <0.4,
+        base <4.12,
+        Cabal <2.3,
+        bytestring <0.11,
+        directory <1.4,
+        filepath <1.5,
+        hackage-db <2.1,
+        MissingH >=1.2.1.0 && <1.5,
+        monad-loops >=0.4.2 && <0.5,
+        network ==2.6.*,
+        process <1.7,
+        transformers <0.6,
+        wreq <0.6,
+        yaml <0.9,
+        codex -any

--- a/src/Codex/Project.hs
+++ b/src/Codex/Project.hs
@@ -20,7 +20,11 @@ import Distribution.Hackage.DB (Hackage, readHackage')
 #endif
 import Distribution.Package
 import Distribution.PackageDescription
+#if MIN_VERSION_hackage_db(2,0,0)
+import Distribution.PackageDescription.Parsec
+#else
 import Distribution.PackageDescription.Parse
+#endif
 import Distribution.Sandbox.Utils (findSandbox)
 import Distribution.Simple.Configure
 import Distribution.Simple.LocalBuildInfo
@@ -66,8 +70,11 @@ allDependencies pd = List.filter (not . isCurrent) $ concat [lds, eds, tds, bds]
 findPackageDescription :: FilePath -> IO (Maybe GenericPackageDescription)
 findPackageDescription root = do
   mpath <- findCabalFilePath root
+#if MIN_VERSION_hackage_db(2,0,0)
+  traverse (readGenericPackageDescription silent) mpath
+#else
   traverse (readPackageDescription silent) mpath
-
+#endif
 -- | Find a regular file ending with ".cabal" within a directory.
 findCabalFilePath :: FilePath -> IO (Maybe FilePath)
 findCabalFilePath path = do

--- a/src/Codex/Project.hs
+++ b/src/Codex/Project.hs
@@ -20,7 +20,7 @@ import Distribution.Hackage.DB (Hackage, readHackage')
 #endif
 import Distribution.Package
 import Distribution.PackageDescription
-#if MIN_VERSION_hackage_db(2,0,0)
+#if MIN_VERSION_Cabal(2,2,0)
 import Distribution.PackageDescription.Parsec
 #else
 import Distribution.PackageDescription.Parse
@@ -70,7 +70,7 @@ allDependencies pd = List.filter (not . isCurrent) $ concat [lds, eds, tds, bds]
 findPackageDescription :: FilePath -> IO (Maybe GenericPackageDescription)
 findPackageDescription root = do
   mpath <- findCabalFilePath root
-#if MIN_VERSION_hackage_db(2,0,0)
+#if MIN_VERSION_Cabal(2,0,0)
   traverse (readGenericPackageDescription silent) mpath
 #else
   traverse (readPackageDescription silent) mpath
@@ -144,7 +144,11 @@ resolveInstalledDependencies bldr root pd = try $ do
       let ipkgs = installedPkgs lbi
           clbis = allComponentsInBuildOrder' lbi
           pkgs  = componentPackageDeps =<< clbis
+#if MIN_VERSION_Cabal(2,0,0)          
+          ys = (maybeToList . lookupUnitId ipkgs) =<< fmap fst pkgs
+#else
           ys = (maybeToList . lookupInstalledPackageId ipkgs) =<< fmap fst pkgs
+#endif
           xs = fmap sourcePackageId $ ys
       return xs where
         withCabal = getPersistBuildConfig $ root </> "dist"

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -6,7 +6,9 @@ packages:
 extra-deps:
   - machines-directory-0.2.0.9
   - machines-io-0.2.0.13
+  - microlens-platform-0.3.10
 flags: {}
 extra-package-dbs: []
 nix:
   packages: [zlib]
+allow-newer: true

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -2,6 +2,9 @@ resolver: lts-11.2
 packages:
 - '.'
 flags: {}
+extra-deps:
+  - microlens-platform-0.3.10
 extra-package-dbs: []
 nix:
   packages: [zlib]
+allow-newer: true

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -1,4 +1,4 @@
-resolver: lts-6.16
+resolver: nightly-2018-05-26
 packages:
 - '.'
 flags: {}

--- a/stack-hasktags.yaml
+++ b/stack-hasktags.yaml
@@ -1,0 +1,5 @@
+resolver: lts-11.2
+packages:
+- '.'
+flags: {}
+allow-newer: true

--- a/stack-test-package-8.2.yaml
+++ b/stack-test-package-8.2.yaml
@@ -1,0 +1,5 @@
+resolver: lts-11.2
+packages:
+- '.'
+flags: {}
+allow-newer: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,0 @@
-stack-8.2.yaml

--- a/test/test-project/.gitignore
+++ b/test/test-project/.gitignore
@@ -1,2 +1,0 @@
-codex.tags
-TAGS

--- a/test/test-project/stack.yaml
+++ b/test/test-project/stack.yaml
@@ -1,8 +1,8 @@
-resolver: lts-6.16
+resolver: lts-11.11
 packages:
 - '.'
-extra-deps: []
 flags: {}
 extra-package-dbs: []
 nix:
   packages: [zlib]
+allow-newer: true

--- a/test/test-project/test-project.cabal
+++ b/test/test-project/test-project.cabal
@@ -10,7 +10,6 @@ maintainer:          example@example.com
 copyright:           2016 Author name here
 category:            Web
 build-type:          Simple
-extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+
 cd "$(dirname "$0")/.."
 
+# cp -f stack-hasktags.yaml stack.yaml
+# this doesn't work for ghc-7.10 because System.Directory is too old
 stack install hasktags
 
 rm -f ~/.codex
-rm -f ./test/test-project/codex.tags
 rm -f ./test/test-project/TAGS
 
-export STACK_YAML="stack.yaml"
 cd ./test/test-project
-codex set tagger hasktags
-codex set format emacs
+echo "Running codex update"
 codex update
 
 tagsFile=codex.tags
@@ -39,4 +39,8 @@ then
     echo "Grepping for someFunc in TAGS was less than 1"
     echo "$someFuncCount"
     exit 1;
+else
+    echo "codex tests finished"
 fi
+
+


### PR DESCRIPTION
Dear Aloïs,

I tried to install codex last night and got some compile errors when compiling it with ghc 8.4.2.  The looked pretty trivial so I went ahead and patched them.  It seems Cabal >= 2.2 changes Distribution.PackageDescription.Parse to Distribution.PackageDescription.Parsec, and renames readPackageDescription to readGenericPackageDescription and lookupInstalledPackageId tolookupUnitId.  I also ran your codex.cabal file through cabal-bounds to reset all of the upper bounds.  That is why your codex.cabal file got reformatted.  I hope this is helpful.

Best wishes,
Henry Laxen
