### PR TITLE
Support Cabal-2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ cabal.sandbox.config
 .stack-work/
 cabal.project.local
 .HTF/
-
+.ghc.environment.*

--- a/codex.cabal
+++ b/codex.cabal
@@ -33,7 +33,7 @@ library
       ascii-progress      >= 0.3
     , base                >= 4.6.0.1    && < 5
     , bytestring          >= 0.10.0.2   && < 0.11
-    , Cabal               >= 1.18       && < 2.1
+    , Cabal               >= 1.18       && < 2.3
     , cryptohash          >= 0.11       && < 0.12
     , containers          >= 0.5.0.0    && < 0.6
     , directory           >= 1.2.0.1    && < 1.4
@@ -73,7 +73,7 @@ executable codex
     , hackage-db
     , MissingH            >= 1.2.1.0    && < 1.5
     , monad-loops         >= 0.4.2      && < 0.5
-    , network             >= 2.6        && < 2.7
+    , network             >= 2.6        && < 2.8
     , process
     , transformers
     , wreq

--- a/codex/Main.hs
+++ b/codex/Main.hs
@@ -31,6 +31,19 @@ import Codex.Project
 import Codex.Internal (Builder(..), hackagePathOf, readStackPath)
 import Main.Config
 
+-- GHC < 8.0
+#if !defined(MIN_VERSION_Cabal)
+# define MIN_VERSION_Cabal(x,y,z) 0
+#endif
+
+#if MIN_VERSION_Cabal(1,24,0)
+index :: String
+index = "01-index.tar"
+#else
+index :: String
+index = "00-index.tar"
+#endif
+
 -- TODO Add 'cache dump' to dump all tags in stdout (usecase: pipe to grep)
 -- TODO Use a mergesort algorithm for `assembly`
 -- TODO Better error handling and fine grained retry
@@ -75,7 +88,7 @@ writeCacheHash cx = writeFile $ hashFile cx
 
 update :: Bool -> Codex -> Builder -> IO ()
 update force cx bldr = displayConsoleRegions $ do
-  (mpid, dependencies, workspaceProjects') <- resolveCurrentProjectDependencies bldr $ hackagePath cx </> "00-index.tar"
+  (mpid, dependencies, workspaceProjects') <- resolveCurrentProjectDependencies bldr $ hackagePath cx </> index
   projectHash <- computeCurrentProjectHash cx
 
   shouldUpdate <-

--- a/src/Codex/Project.hs
+++ b/src/Codex/Project.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE CPP #-}
 module Codex.Project where
 
+-- GHC < 8.0
+#if !defined(MIN_VERSION_Cabal)
+# define MIN_VERSION_Cabal(x,y,z) 0
+#endif
+
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>))
 import Data.Traversable (traverse)
@@ -20,7 +25,11 @@ import Distribution.Hackage.DB (Hackage, readHackage')
 #endif
 import Distribution.Package
 import Distribution.PackageDescription
+#if MIN_VERSION_Cabal(2,2,0)
+import Distribution.PackageDescription.Parsec
+#else
 import Distribution.PackageDescription.Parse
+#endif
 import Distribution.Sandbox.Utils (findSandbox)
 import Distribution.Simple.Configure
 import Distribution.Simple.LocalBuildInfo
@@ -42,6 +51,11 @@ import Codex.Internal (Builder(..), stackListDependencies)
 
 #if MIN_VERSION_hackage_db(2,0,0)
 type Hackage = HackageDB
+#endif
+
+#if MIN_VERSION_Cabal(2,2,0)
+readPackageDescription :: Verbosity -> FilePath -> IO GenericPackageDescription
+readPackageDescription = readGenericPackageDescription
 #endif
 
 newtype Workspace = Workspace [WorkspaceProject]


### PR DESCRIPTION
In my first commit I used macros to figure out the right `index.tar` at compile time, but I realized you could have a `codex` executable built with an older version of `Cabal` running on a project with a newer `Cabal` version.