### PR TITLE
Fix test dependencies for Stack build 7.10/8.0.

### DIFF
--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -1,7 +1,14 @@
 resolver: lts-6.16
 packages:
 - '.'
-extra-deps: []
+extra-deps:
+  - directory-1.2.7.1
+  - microlens-0.4.9.1
+  - microlens-ghc-0.4.9
+  - microlens-mtl-0.1.11.1
+  - microlens-platform-0.3.10
+  - microlens-th-0.4.2.1
+  - th-abstraction-0.2.6.0
 flags: {}
 extra-package-dbs: []
 nix:

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -6,6 +6,12 @@ packages:
 extra-deps:
   - machines-directory-0.2.0.9
   - machines-io-0.2.0.13
+  - microlens-0.4.9.1
+  - microlens-ghc-0.4.9
+  - microlens-mtl-0.1.11.1
+  - microlens-platform-0.3.10
+  - microlens-th-0.4.2.1
+  - th-abstraction-0.2.6.0
 flags: {}
 extra-package-dbs: []
 nix:


### PR DESCRIPTION
This should build the test on CI for 7.10 and 8.0.

I merged a PR that was green but it became red once merged in master.

My gut feeling is that at the time the PR was created the issue did not exists (stack seems mutable somehow, I don't really get it tbh... maybe it's because other deps were upgraded in the meantime, I am unsure).

If Green on Travis, i'll merge it.