### PR TITLE
Stack lts 14.12

### DIFF
--- a/codex.cabal
+++ b/codex.cabal
@@ -41,7 +41,7 @@ library
     , directory           >= 1.2.5.0    && < 1.4
     , filepath            >= 1.3.0.1    && < 1.5
     , hackage-db          >= 1.22       && < 3
-    , http-client         >= 0.4        && < 0.6
+    , http-client         >= 0.4        && <= 0.6.4
     , lens                >= 4.6        && < 5
     , machines            >= 0.2        && < 0.7
     , machines-directory  >= 0.0.0.2    && < 0.3

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -1,0 +1,7 @@
+resolver: lts-14.12
+packages:
+  - '.'
+flags: {}
+extra-package-dbs: []
+nix:
+  packages: [zlib]


### PR DESCRIPTION
PR aims to add support [LTS Haskell 14.12 (ghc-8.6.5)](https://www.stackage.org/lts-14.12)
It doesn't contain any code changes.