### PR TITLE
Update dependency version bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ When editing this file, please include a link to the PR and/or issue for
 the change.  
 -->
 
+## Unreleased
+
+- Bump dependency version bounds [#106](https://github.com/aloiscochard/codex/pull/106)
+
 ## 0.6.0.0
 
 - Bump `base` lower bound to indicate GHC 7.10 as minimum supported version.

--- a/codex.cabal
+++ b/codex.cabal
@@ -34,16 +34,16 @@ library
   build-depends:
       ascii-progress      >= 0.3
     , base                >= 4.11       && < 5
-    , bytestring          >= 0.10.0.2   && < 0.11
+    , bytestring          >= 0.10.0.2   && < 0.12
     , conduit             >= 1.3.0
-    , Cabal               >= 3.0        && < 3.1
+    , Cabal               >= 3.0        && < 3.5
     , containers          >= 0.5.0.0    && < 0.7
-    , cryptonite          >= 0.21       && < 0.27
+    , cryptonite          >= 0.21       && < 0.30
     , directory           >= 1.2.5.0    && < 1.4
     , filepath            >= 1.3.0.1    && < 1.5
     , hackage-db          >= 2          && < 3
-    , http-client         >= 0.4        && <= 0.6.5
-    , memory              >= 0.13       && < 0.16
+    , http-client         >= 0.4        && <= 0.8
+    , memory              >= 0.13       && < 0.17
     , process             >= 1.2.3      && < 1.7
     , tar                 >= 0.4.0.1    && < 0.6
     , text                >= 1.1.1.3    && < 1.3


### PR DESCRIPTION
# Description

Update dependency version bounds, to make them up to date and make it build with nix 21.05.

# Process Checklist

Tested on the streamly package

```
$ codex update
codex: Run the 'configure' command first.
codex: *warning* falling back on dependency resolution using hackage
codex: Run the 'configure' command first.
codex: *warning* falling back on dependency resolution using hackage
codex: Run the 'configure' command first.
codex: *warning* falling back on dependency resolution using hackage
codex: Run the 'configure' command first.
codex: *warning* falling back on dependency resolution using hackage
codex: Run the 'configure' command first.
codex: *warning* falling back on dependency resolution using hackage
Updating: streamly-0.7.2 streamly-benchmarks-0.0.0 bench-report-0.0.0 streamly-docs-0.0.0 streamly-tests-0.0.0
Loading tags 100% [=======================]  27/ 27 (for   3.2,   0.0 remaining)
Running tagger 100% [=====================]   5/  5 (for   1.8,   0.0 remaining)
Merging tags 100% [=======================]  32/ 32 (for   0.0,   0.0 remaining)
```